### PR TITLE
⚙️ config: increase chunk size warning limit in vite config

### DIFF
--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -3,13 +3,16 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-	plugins: [react()],
-	resolve: {
-		alias: {
-			"@": path.resolve(__dirname, "./src"),
-		},
-	},
-	server: {
-		port: 3000,
-	},
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  server: {
+    port: 3000,
+  },
+  build: {
+    chunkSizeWarningLimit: 1600,
+  },
 });


### PR DESCRIPTION
1. added build configuration to vite.config.ts
2. set chunkSizeWarningLimit to 1600 in the build options
3. adjusted indentation to use 2 spaces instead of tabs for consistency